### PR TITLE
Fixes typos in README (image name in Docker Hub)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ Dockerized lizard
 
 [Lizard](https://github.com/terryyin/lizard) is an extensible Cyclomatic Complexity Analyzer for many programming languages including C/C++ (doesn't require all the header files or Java imports). It also does copy-paste detection (code clone detection/code duplicate detection) and many other forms of static code analysis.
 
-> docker run -v $PWD:/lizard --rm srzzuimx/lizard
+> docker run -v $PWD:/lizard --rm srzzumix/lizard
 
-> docker run -v $PWD:/lizard --rm srzzuimx/lizard -l cpp -o report.html --html
+> docker run -v $PWD:/lizard --rm srzzumix/lizard -l cpp -o report.html --html


### PR DESCRIPTION
Just fixes errors in docker image name.